### PR TITLE
Automatically remove old media

### DIFF
--- a/src/Database/Migrations/2020_10_23_192428_add_synced_at_to_products_media_table.php
+++ b/src/Database/Migrations/2020_10_23_192428_add_synced_at_to_products_media_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSyncedAtToProductsMediaTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('magento_product_media', function (Blueprint $table) {
+            $table->timestamp('synced_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/src/Database/Migrations/2020_10_23_192428_add_synced_at_to_products_media_table.php
+++ b/src/Database/Migrations/2020_10_23_192428_add_synced_at_to_products_media_table.php
@@ -14,7 +14,7 @@ class AddSyncedAtToProductsMediaTable extends Migration
     public function up()
     {
         Schema::table('magento_product_media', function (Blueprint $table) {
-            $table->timestamp('synced_at')->useCurrent();
+            $table->timestamp('synced_at')->nullable();
         });
     }
 

--- a/src/Models/MagentoProductMedia.php
+++ b/src/Models/MagentoProductMedia.php
@@ -20,7 +20,15 @@ class MagentoProductMedia extends Model
         'disabled',
         'types',
         'file',
+        'synced_at',
     ];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = ['created_at', 'updated_at', 'synced_at'];
 
     /**
      * The attributes that should be cast to native types.

--- a/src/Support/HasMediaEntries.php
+++ b/src/Support/HasMediaEntries.php
@@ -27,6 +27,7 @@ trait HasMediaEntries
                 'disabled'   => $image['disabled'],
                 'types'      => $image['types'],
                 'file'       => $image['file'],
+                'synced_at'  => now(),
             ]);
 
             DownloadMagentoProductImage::dispatch($image['file']);

--- a/src/Support/HasMediaEntries.php
+++ b/src/Support/HasMediaEntries.php
@@ -2,9 +2,9 @@
 
 namespace Grayloon\MagentoStorage\Support;
 
+use Grayloon\MagentoStorage\Jobs\DownloadMagentoProductImage;
 use Grayloon\MagentoStorage\Models\MagentoProduct;
 use Grayloon\MagentoStorage\Models\MagentoProductMedia;
-use Grayloon\MagentoStorage\Jobs\DownloadMagentoProductImage;
 
 trait HasMediaEntries
 {
@@ -18,7 +18,7 @@ trait HasMediaEntries
     public function downloadProductImages($images, MagentoProduct $product)
     {
         $product->images()->delete();
-        
+
         foreach ($images as $image) {
             MagentoProductMedia::updateOrCreate([
                 'id'         => $image['id'],

--- a/src/Support/HasMediaEntries.php
+++ b/src/Support/HasMediaEntries.php
@@ -2,8 +2,9 @@
 
 namespace Grayloon\MagentoStorage\Support;
 
-use Grayloon\MagentoStorage\Jobs\DownloadMagentoProductImage;
+use Grayloon\MagentoStorage\Models\MagentoProduct;
 use Grayloon\MagentoStorage\Models\MagentoProductMedia;
+use Grayloon\MagentoStorage\Jobs\DownloadMagentoProductImage;
 
 trait HasMediaEntries
 {
@@ -14,8 +15,10 @@ trait HasMediaEntries
      * @param  \Grayloon\Magento\Models\MagentoProduct  $product
      * @return void
      */
-    public function downloadProductImages($images, $product)
+    public function downloadProductImages($images, MagentoProduct $product)
     {
+        $product->images()->delete();
+        
         foreach ($images as $image) {
             MagentoProductMedia::updateOrCreate([
                 'id'         => $image['id'],
@@ -29,7 +32,6 @@ trait HasMediaEntries
                 'file'       => $image['file'],
                 'synced_at'  => now(),
             ]);
-
             DownloadMagentoProductImage::dispatch($image['file']);
         }
 

--- a/tests/Support/HasMediaEntriesTest.php
+++ b/tests/Support/HasMediaEntriesTest.php
@@ -106,6 +106,40 @@ class HasMediaEntriesTest extends TestCase
         $this->assertEquals('foo', MagentoProductMedia::first()->label);
     }
 
+    public function test_deletes_and_doesnt_persist_existing_image()
+    {
+        Queue::fake();
+
+        $product = MagentoProductFactory::new()->create();
+        $image = MagentoProductMediaFactory::new()->create([
+            'id' => 1,
+            'product_id' => $product->id,
+            'label' => null,
+        ]);
+
+        $images = [
+            [
+                'id' => 2,
+                'media_type' => 'image',
+                'label' => 'foo',
+                'position' => 1,
+                'disabled' => false,
+                'types' => [
+                    'image',
+                    'small_image',
+                    'thumbnail',
+                ],
+                'file' => '/p/paper.jpg',
+            ],
+        ];
+
+        (new FakeSupportingMediaEntriesClass)->exposedDownloadProductImages($images, $product);
+
+        $this->assertEquals(1, MagentoProductMedia::count());
+        $this->assertEquals('foo', MagentoProductMedia::first()->label);
+        $this->assertEquals(2, MagentoProductMedia::first()->id);
+    }
+
     public function test_product_images_can_receive_empty_images_result()
     {
         $product = MagentoProductFactory::new()->create();


### PR DESCRIPTION
PR automatically pulls any existing media and refreshes with new content. Useful if an image is deleted in Magento.