### PR TITLE
Adds: Website/Store ID filtering on product sync

### DIFF
--- a/src/Jobs/SyncMagentoProductSingle.php
+++ b/src/Jobs/SyncMagentoProductSingle.php
@@ -51,8 +51,13 @@ class SyncMagentoProductSingle implements ShouldQueue
             throw new Exception('Error fetching SKU: '.$this->sku.' Error: '.$apiProduct->json()['body'] ?? 'N/A');
         }
 
-        $product = (new MagentoProducts())->updateOrCreateProduct($apiProduct->json());
+        if (in_array(config('magento.default_store_id'), ($apiProduct->json())['extension_attributes']['website_ids'])) {
+            $product = (new MagentoProducts())->updateOrCreateProduct($apiProduct->json());
 
-        event(new MagentoProductSynced($product));
+            event(new MagentoProductSynced($product));
+        } else {
+            // product doesnt exist in given website
+            return (new MagentoProducts())->deleteIfExists($this->sku);
+        }
     }
 }

--- a/src/Support/MagentoProducts.php
+++ b/src/Support/MagentoProducts.php
@@ -98,7 +98,9 @@ class MagentoProducts extends PaginatableMagentoService
     {
         $product = MagentoProduct::where('sku', $sku)->first();
 
-        $product->delete();
+        if ($product) {
+            $product->delete();
+        }
 
         return $this;
     }


### PR DESCRIPTION
I'm assuming the Product returned always has an array property called `'extension_attributes'` that, in turn, has an array of single IDs called `'website_ids'`.