### PR TITLE
Remove Old Links; Cleanup

### DIFF
--- a/src/Support/HasProductLinks.php
+++ b/src/Support/HasProductLinks.php
@@ -42,13 +42,12 @@ trait HasProductLinks
             return WaitForLinkedProductSku::dispatch($product, $link);
         }
 
-        MagentoProductLink::updateOrCreate([
+        MagentoProductLink::create([
             'product_id'         => $product->id,
             'related_product_id' => $productLink->id,
-        ], [
-            'link_type'   => $link['link_type'],
-            'position'    => $link['position'],
-            'synced_at'   => now(),
+            'link_type'          => $link['link_type'],
+            'position'           => $link['position'],
+            'synced_at'          => now(),
         ]);
     }
 }

--- a/src/Support/HasProductLinks.php
+++ b/src/Support/HasProductLinks.php
@@ -17,6 +17,9 @@ trait HasProductLinks
      */
     protected function syncProductLinks($links, $product)
     {
+        MagentoProductLink::where('product_id', $product->id)
+            ->delete();
+
         foreach ($links as $link) {
             $this->updateProductLink($link, $product);
         }

--- a/tests/Support/HasProductLinkTest.php
+++ b/tests/Support/HasProductLinkTest.php
@@ -91,6 +91,21 @@ class HasProductLinkTest extends TestCase
 
         $this->assertEquals(0, MagentoProductLink::count());
     }
+
+    /** @test */
+    public function it_removes_old_product_links()
+    {
+        $product = MagentoProductFactory::new()->create([
+            'id' => 5,
+        ]);
+        $link = MagentoProductLinkFactory::new()->create([
+            'product_id' => $product->id,
+        ]);
+
+        (new FakeProductLinksSupportingTest)->exposedSyncProductLinks([], $product);
+
+        $this->assertEquals(0, MagentoProductLink::count());
+    }
 }
 
 class FakeProductLinksSupportingTest


### PR DESCRIPTION
PR removes old links that are out-of-sync and cleans up the tasks that waits on a model state to use the conventional laravel job retry.