### PR TITLE
Use stable magento-storage-api

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.4",
         "doctrine/dbal": "^2.9|^3.0",
-        "grayloon/laravel-magento-api": "dev-master|^0.9",
+        "grayloon/laravel-magento-api": "^0.9",
         "guzzlehttp/guzzle": "^7.0",
         "illuminate/support": "^8.0"
     },


### PR DESCRIPTION
PR forces ^0.9. Prevents future bugs.