### PR TITLE
Allow Special Sale Price to run through current date

### DIFF
--- a/src/Models/MagentoProduct.php
+++ b/src/Models/MagentoProduct.php
@@ -161,6 +161,7 @@ class MagentoProduct extends Model
         }
         if ($saleEnd) {
             $saleEnd = new Carbon($saleEnd->value);
+            $saleEnd = $saleEnd->endOfDay();
         }
 
         if ($saleStart) {

--- a/tests/Models/MagentoProductModelTest.php
+++ b/tests/Models/MagentoProductModelTest.php
@@ -343,6 +343,24 @@ class MagentoProductModelTest extends TestCase
         $this->assertEquals('9.99', $product->load('customAttributes')->salePrice());
     }
 
+    public function test_sale_price_runs_through_current_date_on_special_to_date()
+    {
+        $product = MagentoProductFactory::new()->create();
+
+        $product->customAttributes()->create([
+            'attribute_type'    => 'special_price',
+            'attribute_type_id' => MagentoCustomAttributeTypeFactory::new()->create(),
+            'value'             => '9.99',
+        ]);
+        $product->customAttributes()->create([
+            'attribute_type'    => 'special_to_date',
+            'attribute_type_id' => MagentoCustomAttributeTypeFactory::new()->create(),
+            'value'             => today()->format('Y-m-d H:i:s'),
+        ]);
+
+        $this->assertEquals('9.99', $product->load('customAttributes')->salePrice());
+    }
+
     public function test_configurable_links_has_many_products_through()
     {
         $configurableProduct = MagentoProductFactory::new()->create();


### PR DESCRIPTION
This PR allows Sales Dates to run through the current date instead of stopping at 00:00:00.

The Magento UI reads: sale from: (date) to: (date)

The `special_to_date` is a date string, `2021-04-01`, for example, when parsed to Carbon formats the DateTime as `2021-04-1 00:00:00`.

Naturally, when checking the condition if the sale dates are valid on current date will return false when it should allow the sale to extend to the end of the day.