### PR TITLE
Skip link to non-existent category

### DIFF
--- a/src/Jobs/SyncMagentoProductCategory.php
+++ b/src/Jobs/SyncMagentoProductCategory.php
@@ -2,13 +2,14 @@
 
 namespace Grayloon\MagentoStorage\Jobs;
 
-use Grayloon\MagentoStorage\Models\MagentoProduct;
-use Grayloon\MagentoStorage\Models\MagentoProductCategory;
 use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
+use Grayloon\MagentoStorage\Models\MagentoProduct;
+use Grayloon\MagentoStorage\Models\MagentoCategory;
+use Grayloon\MagentoStorage\Models\MagentoProductCategory;
 
 class SyncMagentoProductCategory implements ShouldQueue
 {
@@ -63,9 +64,14 @@ class SyncMagentoProductCategory implements ShouldQueue
     {
         $this->product = MagentoProduct::where('sku', $this->sku)->firstOrFail();
 
-        MagentoProductCategory::updateOrCreate([
-            'magento_product_id'  => $this->product->id,
-            'magento_category_id' => $this->categoryId,
-        ], ['position'            => $this->position]);
+        // verify that the category exists.
+        $category = MagentoCategory::find($this->categoryId);
+
+        if ($category) {
+            MagentoProductCategory::updateOrCreate([
+                'magento_product_id'  => $this->product->id,
+                'magento_category_id' => $this->categoryId,
+            ], ['position'            => $this->position]);
+        }
     }
 }

--- a/src/Support/HasExtensionAttributes.php
+++ b/src/Support/HasExtensionAttributes.php
@@ -43,10 +43,14 @@ trait HasExtensionAttributes
     protected function resolveCategoryLinks($links, $product)
     {
         foreach ($links as $link) {
-            MagentoProductCategory::updateOrCreate([
-                'magento_product_id'  => $product->id,
-                'magento_category_id' => MagentoCategory::find($link['category_id'])->id,
-            ], ['position'            => $link['position']]);
+            $category = MagentoCategory::find($link['category_id']);
+
+            if ($category) {
+                MagentoProductCategory::updateOrCreate([
+                    'magento_product_id'  => $product->id,
+                    'magento_category_id' => $category->id,
+                ], ['position'            => $link['position']]);
+            }
         }
     }
 }

--- a/tests/Jobs/SyncMagentoProductCategoryTest.php
+++ b/tests/Jobs/SyncMagentoProductCategoryTest.php
@@ -49,4 +49,14 @@ class SyncMagentoProductCategoryTest extends TestCase
 
         SyncMagentoProductCategory::dispatchNow('foo', $category->id, 1);
     }
+
+    /** @test */
+    public function it_doesnt_sync_product_with_missing_category()
+    {
+        $product = MagentoProductFactory::new()->create();
+
+        SyncMagentoProductCategory::dispatchNow($product->sku, 123, 1);
+
+        $this->assertEquals(0, MagentoProductCategory::count());
+    }
 }

--- a/tests/Support/HasExtensionAttributesTest.php
+++ b/tests/Support/HasExtensionAttributesTest.php
@@ -59,6 +59,21 @@ class HasExtensionAttributesTest extends TestCase
         $this->assertEquals($category->id, MagentoProductCategory::first()->magento_category_id);
         $this->assertEquals($product->id, MagentoProductCategory::first()->magento_product_id);
     }
+
+    /** @test */
+    public function it_skips_categories_that_dont_exist_in_database()
+    {
+        $product = MagentoProductFactory::new()->create();
+
+        (new FakeSupportingExtensionClass)->exposedSyncExtensionAttributes(['category_links' => [
+            [
+                'category_id' => "123",
+                'position'    => 1,
+            ],
+        ]], $product);
+
+        $this->assertEquals(0, MagentoProductCategory::count());
+    }
 }
 
 class FakeSupportingExtensionClass


### PR DESCRIPTION
Prevents ErrorException: Trying to get property 'id' of non-object in /vendor/grayloon/laravel-magento-storage/src/Support/HasExtensionAttributes.php:48

When categories from other sites are linked but don't exist on the current website.